### PR TITLE
Add locale static params

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ The middleware in [`middleware.ts`](middleware.ts) now detects the locale from t
 URL. Requests without a locale prefix are redirected to `/uk` by default and an
 `X-Art-Culture` header is added to all responses.
 
+### Supported Locales
+
+Pages are available in Ukrainian (`uk`) and English (`en`). These locales are
+pre-rendered at build time.
+
 A demo SSR page is available at [`src/pages/ssr.js`](src/pages/ssr.js) which uses `getServerSideProps` to select a random news item on each request.
 
 ## Static Regeneration

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,1 +1,5 @@
 export { default } from '../page'
+
+export function generateStaticParams() {
+  return [{ locale: 'uk' }, { locale: 'en' }]
+}


### PR DESCRIPTION
## Summary
- pre-render `/uk` and `/en` by defining `generateStaticParams`
- document supported locales in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461bb7b2b08323a9a002621f2cc445