### PR TITLE
Fix layout props type

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,11 +1,9 @@
 import { ReactNode } from 'react'
+import type { LayoutProps } from 'next'
 
-interface LocaleLayoutProps {
-  children: ReactNode
-  params: { locale: string }
-}
-
-export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
+export default function LocaleLayout(
+  { children, params }: LayoutProps<{ locale: string }>
+) {
   return (
     <html lang={params.locale}>
       <body>{children}</body>


### PR DESCRIPTION
## Summary
- remove custom `LocaleLayoutProps` interface
- use Next.js `LayoutProps` type in the locale layout file

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846360b101483238651de45b46b8aee