### PR TITLE
fix(build): ensure base URL for SSG

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # Example environment variables for Art & Culture
 # Base URL used by fetch() in server components
-NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000 # Required for `npm run build`. Replace with your production URL
 API_BASE_URL=http://localhost:5000
 NEXT_PUBLIC_API_URL=http://localhost:5000
 REACT_APP_API_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Copy `.env.sample` to `.env` and update the values as needed.
 - `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`
 - `NEXTAUTH_SECRET` and provider credentials like `GITHUB_ID`/`GITHUB_SECRET`
 - `NEXT_PUBLIC_HOST` – hostname used when rendering on the server
-- `NEXT_PUBLIC_API_BASE_URL` – base URL used by server components to fetch internal API routes
+- `NEXT_PUBLIC_API_BASE_URL` – base URL used by server components to fetch internal API routes. This must be set for production builds and defaults to `http://localhost:3000` during development
 - `API_BASE_URL` - fallback base URL for server-side API utilities
 - `TOKEN` - access token for internal APIs
 - `NEXT_PUBLIC_API_URL` is no longer used and can be removed

--- a/__tests__/generateStaticParams.test.ts
+++ b/__tests__/generateStaticParams.test.ts
@@ -1,0 +1,25 @@
+/** @jest-environment node */
+import { jest } from '@jest/globals'
+import { generateStaticParams } from '../src/app/news/[id]/page'
+import { newsList } from '../src/data/news'
+
+describe('generateStaticParams', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: 'production', NEXT_PUBLIC_API_BASE_URL: 'http://localhost:3000' }
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => newsList }) as any
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    ;(global.fetch as unknown as jest.Mock).mockReset()
+  })
+
+  test('returns params when API_BASE_URL is provided', async () => {
+    const params = await generateStaticParams()
+    expect(params.length).toBeGreaterThan(0)
+    expect(params[0]).toHaveProperty('id')
+    expect(global.fetch).toHaveBeenCalled()
+  })
+})

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,11 @@
 import path from 'path';
 
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+
+if (process.env.NODE_ENV === 'production' && !process.env.NEXT_PUBLIC_API_BASE_URL) {
+  throw new Error('NEXT_PUBLIC_API_BASE_URL must be defined during build');
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
@@ -10,7 +16,7 @@ const nextConfig = {
     return config;
   },
   env: {
-    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+    NEXT_PUBLIC_API_BASE_URL: apiBaseUrl,
   },
 };
 

--- a/src/app/news/[id]/page.tsx
+++ b/src/app/news/[id]/page.tsx
@@ -8,25 +8,20 @@ const window = new JSDOM('').window
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const DOMPurify = createDOMPurify(window as any)
 import { NewsItem } from '@/data/news'
+import { getApiBaseUrl } from '@/utils/getApiBaseUrl'
 
 // Incremental static regeneration
 export const revalidate = 60
 
 export async function generateStaticParams() {
-  const baseUrl =
-    process.env.NODE_ENV === 'production'
-      ? process.env.NEXT_PUBLIC_API_BASE_URL
-      : 'http://localhost:3000'
+  const baseUrl = getApiBaseUrl()
   const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   return newsList.map((n) => ({ id: n.id }))
 }
 
 export async function generateMetadata({ params }: PageProps<{ id: string }>) {
-  const baseUrl =
-    process.env.NODE_ENV === 'production'
-      ? process.env.NEXT_PUBLIC_API_BASE_URL
-      : 'http://localhost:3000'
+  const baseUrl = getApiBaseUrl()
   const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id)
@@ -46,10 +41,7 @@ export async function generateMetadata({ params }: PageProps<{ id: string }>) {
 }
 
 export default async function NewsPage({ params }: PageProps<{ id: string }>) {
-  const baseUrl =
-    process.env.NODE_ENV === 'production'
-      ? process.env.NEXT_PUBLIC_API_BASE_URL
-      : 'http://localhost:3000'
+  const baseUrl = getApiBaseUrl()
   const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id) as NewsItem

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -2,12 +2,13 @@
 
 import Link from 'next/link'
 import { NewsItem } from '@/data/news'
+import { getApiBaseUrl } from '@/utils/getApiBaseUrl'
 
 export const revalidate = 60  // ISR: рефреш раз на 60 секунд
 
 export default async function NewsIndex() {
   // Визначаємо базовий URL один раз
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000'
+  const baseUrl = getApiBaseUrl()
 
   // Виконуємо запит із кешуванням ISR
   const res = await fetch(`${baseUrl}/api/news`, { next: { revalidate } })

--- a/src/utils/getApiBaseUrl.ts
+++ b/src/utils/getApiBaseUrl.ts
@@ -1,0 +1,8 @@
+export function getApiBaseUrl(): string {
+  const fallback = 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || fallback
+  if (process.env.NODE_ENV === 'production' && !process.env.NEXT_PUBLIC_API_BASE_URL) {
+    throw new Error('NEXT_PUBLIC_API_BASE_URL must be defined in production')
+  }
+  return baseUrl
+}


### PR DESCRIPTION
## Summary
- provide fallback API base URL via `getApiBaseUrl`
- enforce missing URL error in production
- document `NEXT_PUBLIC_API_BASE_URL` usage
- update Next.js config with default and check
- add smoke test for `generateStaticParams`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684747225b348323be245011c196aa74