### PR TITLE
Add JSDOM cleanup in sanitizer tests

### DIFF
--- a/__tests__/sanitizer.test.ts
+++ b/__tests__/sanitizer.test.ts
@@ -9,3 +9,7 @@ test('unsafe HTML is sanitized', () => {
   const dirty = '<img src=x onerror=alert(1)><script>alert(1)</script><p>hi</p>'
   expect(DOMPurify.sanitize(dirty)).toBe('<img src="x"><p>hi</p>')
 })
+
+afterAll(() => {
+  window.close()
+})


### PR DESCRIPTION
## Summary
- release JSDOM resources in sanitizer test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847669da854832398f9c85eb6d67f40