### PR TITLE
Add Jest debug script

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ To continually run tests as files change, use watch mode:
 npm run test:watch
 ```
 
+For more verbose output and handle detection, run the debug command:
+
+```bash
+npm run test:debug
+```
+
 ## SEO
 
 SEO metadata is defined in [`src/meta/index.js`](src/meta/index.js).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "preview": "next preview",
     "test": "jest --runInBand",
     "sitemap": "next-sitemap",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:debug": "jest --runInBand --detectOpenHandles --verbose"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.80.6",


### PR DESCRIPTION
## Summary
- add `test:debug` npm script for detailed Jest output
- document `npm run test:debug` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684766a0f3988323a575f668a18b3b7e