### PR TITLE
Add global jest teardown

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -2,3 +2,7 @@ require('@testing-library/jest-dom');
 const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+afterEach(() => {
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- restore real timers after each test globally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684769d9a42c8323848491aba548ac22