### PR TITLE
Add test debug command

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To continually run tests as files change, use watch mode:
 npm run test:watch
 ```
 
-For more verbose output and handle detection, run the debug command:
+If tests hang, run the debug command to detect open handles:
 
 ```bash
 npm run test:debug

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "jest --runInBand",
     "sitemap": "next-sitemap",
     "test:watch": "jest --watch",
-    "test:debug": "jest --runInBand --detectOpenHandles --verbose"
+    "test:debug": "jest --runInBand --detectOpenHandles"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.80.6",


### PR DESCRIPTION
## Summary
- streamline `test:debug` command
- clarify README on using `test:debug` when tests hang

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684769dc91fc832384258d32abd49bb5