### PR TITLE
Add test for getApiBaseUrl env rules

### DIFF
--- a/__tests__/env-and-css.test.js
+++ b/__tests__/env-and-css.test.js
@@ -1,0 +1,25 @@
+/** @jest-environment node */
+import { getApiBaseUrl } from '../src/utils/getApiBaseUrl'
+
+describe('getApiBaseUrl', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('returns base url when NEXT_PUBLIC_API_BASE_URL is set', () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.example.com'
+    expect(getApiBaseUrl()).toBe('https://api.example.com')
+  })
+
+  test('throws in production when NEXT_PUBLIC_API_BASE_URL is missing', () => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL
+    process.env.NODE_ENV = 'production'
+    expect(() => getApiBaseUrl()).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- add `env-and-css.test.js` to verify `getApiBaseUrl`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476ec85ef483239f174d77b25d61fd