### PR TITLE
Add alias import test

### DIFF
--- a/__tests__/alias.test.ts
+++ b/__tests__/alias.test.ts
@@ -1,0 +1,11 @@
+/** @jest-environment node */
+import page from '@/app/news/[id]/page'
+import { getApiBaseUrl } from '@/utils/getApiBaseUrl'
+
+test('alias import for page works', () => {
+  expect(typeof page).toBe('function')
+})
+
+test('alias import for util works', () => {
+  expect(typeof getApiBaseUrl).toBe('function')
+})


### PR DESCRIPTION
## Summary
- ensure alias imports function in test suite

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684779b030f08323880678d64cd81f46